### PR TITLE
Bugfixes and additional APIs required for Goofyscache compatibility with goofys v0.24

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -187,5 +187,7 @@ var (
 )
 
 type (
-	Goofys = internal.Goofys
+	// Needed to expose new API method ListBlobs()
+	BlobItemOutput = internal.BlobItemOutput
+	Goofys         = internal.Goofys
 )

--- a/api/common/conf_s3.go
+++ b/api/common/conf_s3.go
@@ -114,6 +114,9 @@ func (c *S3Config) ToAwsConfig(flags *FlagStorage) (*aws.Config, error) {
 				}
 				p.RoleSessionName = c.RoleSessionName
 			})
+	} else if c.Credentials == nil {
+		// If neither RoleArn or AccessKey is set, use AnonymousCredentials
+		c.Credentials = credentials.AnonymousCredentials
 	}
 
 	if c.Credentials != nil {

--- a/api/common/logger.go
+++ b/api/common/logger.go
@@ -119,14 +119,14 @@ func GetLogger(name string) *LogHandle {
 
 	if logger, ok := loggers[name]; ok {
 		if name != "main" && name != "fuse" {
-			logger.Level = cloudLogLevel
+			logger.SetLevel(cloudLogLevel)
 		}
 		return logger
 	} else {
 		logger := NewLogger(name)
 		loggers[name] = logger
 		if name != "main" && name != "fuse" {
-			logger.Level = cloudLogLevel
+			logger.SetLevel(cloudLogLevel)
 		}
 		return logger
 	}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1224,7 +1224,7 @@ func (fs *Goofys) GetFileSize(path string) (uint64, error) {
 	return headOutput.BlobItemOutput.Size, nil
 }
 
-func (fs *Goofys) DownloadToFile(ctx context.Context, key string, count int, target *os.File) (uint64, error) {
+func (fs *Goofys) DownloadToFile(ctx context.Context, key string, count uint64, target *os.File) (uint64, error) {
 	rawS3, err := fs.GetRawS3()
 	if err == nil {
 		// No error means it's an S3 backend and we can use the downloader
@@ -1241,7 +1241,7 @@ func (fs *Goofys) DownloadToFile(ctx context.Context, key string, count int, tar
 	}
 	// Otherwise just fall back to GetBlob()
 	getBlobOutput, err := fs.storageBackend.GetBlob(&GetBlobInput{
-		Key:   &key,
+		Key:   key,
 		Start: 0,
 		Count: count,
 	})

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1265,11 +1265,10 @@ func (fs *Goofys) getRawS3() (*s3.S3, error) {
 	return nil, fmt.Errorf("Backend Config is not S3")
 }
 
-
 // ListBlobs is a public method on goofys that lets callers iterate over files in the configured backend
 // and execute a function on each page of Blobs.
 // NOTE: The bulk of this was inspired and copied from internal/dir.go/listBlobsSafe()
-func (fs *Goofys) ListBlobs(ctx, context.Context, prefix string, fn func([]BlobItemOutput) bool) error {
+func (fs *Goofys) ListBlobs(ctx context.Context, prefix string, fn func([]BlobItemOutput) bool) error {
 	res := &ListBlobsOutput{
 		IsTruncated: true, // Just to get the loop started
 	}
@@ -1279,7 +1278,7 @@ func (fs *Goofys) ListBlobs(ctx, context.Context, prefix string, fn func([]BlobI
 			break
 		}
 		listBlobsInput := &ListBlobsInput{
-			Prefix:    &prefix,
+			Prefix: &prefix,
 			// Get the continuation token from the prior result.
 			ContinuationToken: res.NextContinuationToken,
 		}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1211,6 +1211,14 @@ func (fs *Goofys) GetFullName(id fuseops.InodeID) *string {
 	return inode.FullName()
 }
 
+func (gc *GoofysCacheBucket) GetFileSize(path string) (uint64, error) {
+	headOutput, err := fs.storageBackend.HeadBlob(&HeadBlobInput{Key: path})\
+	if err != nil {
+		return 0, err
+	}
+	return headOutput.BlobItemOutput.Size, nil
+}
+
 // Expose the raw S3 object from the underlying 'storageBackend'.
 // Will error if the 'storageBackend' is not 'S3Backend' or 'GCS3' backend
 func (fs *Goofys) GetRawS3() (*s3.S3, error) {

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1282,7 +1282,8 @@ func (fs *Goofys) ListBlobs(ctx context.Context, prefix string, fn func([]BlobIt
 			// Get the continuation token from the prior result.
 			ContinuationToken: res.NextContinuationToken,
 		}
-		res, err := fs.storageBackend.ListBlobs(listBlobsInput)
+		var err error
+		res, err = fs.storageBackend.ListBlobs(listBlobsInput)
 		if err != nil {
 			return err
 		}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1282,7 +1282,7 @@ func (fs *Goofys) ListBlobs(ctx context.Context, prefix string, fn func([]BlobIt
 			// Get the continuation token from the prior result.
 			ContinuationToken: res.NextContinuationToken,
 		}
-		res, err = fs.storageBackend.ListBlobs(listBlobsInput)
+		res, err := fs.storageBackend.ListBlobs(listBlobsInput)
 		if err != nil {
 			return err
 		}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1211,8 +1211,8 @@ func (fs *Goofys) GetFullName(id fuseops.InodeID) *string {
 	return inode.FullName()
 }
 
-func (gc *GoofysCacheBucket) GetFileSize(path string) (uint64, error) {
-	headOutput, err := fs.storageBackend.HeadBlob(&HeadBlobInput{Key: path})\
+func (fs *Goofys) GetFileSize(path string) (uint64, error) {
+	headOutput, err := fs.storageBackend.HeadBlob(&HeadBlobInput{Key: path})
 	if err != nil {
 		return 0, err
 	}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1245,6 +1245,9 @@ func (fs *Goofys) DownloadToFile(ctx context.Context, key string, count uint64, 
 		Start: 0,
 		Count: count,
 	})
+	if err != nil {
+		return 0, err
+	}
 	written, err := io.Copy(target, getBlobOutput.Body)
 	getBlobOutput.Body.Close()
 	return uint64(written), err

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"net/url"
 	"runtime/debug"
 	"strings"
@@ -35,7 +36,6 @@ import (
 	"github.com/jacobsa/fuse/fuseutil"
 
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 // goofys is a Filey System written in Go. All the backend data is
@@ -1194,4 +1194,16 @@ func (fs *Goofys) Rename(
 		}
 	}
 	return
+}
+
+// return full name of the given inode
+func (fs *Goofys) GetFullName(id fuseops.InodeID) *string {
+	fs.mu.Lock()
+	inode := fs.inodes[id]
+	fs.mu.Unlock()
+	if inode == nil {
+		return nil
+	}
+	return inode.FullName()
+
 }


### PR DESCRIPTION
PR to house the changes goofyscache needs to work with S3 with the updated v0.24 of goofys

(NOTE: Azure support will come later)